### PR TITLE
Fix typo ip4 => tcp4, code may not working

### DIFF
--- a/zh/Text/chapter-socket.html
+++ b/zh/Text/chapter-socket.html
@@ -693,7 +693,7 @@ func (l *TCPListener) Accept() (c Conn, err os.Error)
 <span class="sgc-2">func</span> main() {
 
         service := <span class="sgc-3">":1200"</span>
-        tcpAddr, err := net.<span class="sgc-4">ResolveTCPAddr</span>(<span class="sgc-3">"ip4"</span>, service)
+        tcpAddr, err := net.<span class="sgc-4">ResolveTCPAddr</span>(<span class="sgc-3">"tcp4"</span>, service)
         checkError(err)
 
         listener, err := net.<span class="sgc-4">ListenTCP</span>(<span class="sgc-3">"tcp"</span>, tcpAddr)


### PR DESCRIPTION
Due to typo in code example. the source code not working. so i fixed it
Signed-off-by: ZhiFeng Hu <hufeng1987@gmail.com>